### PR TITLE
Fix file handle closing in updateRowWithID

### DIFF
--- a/lib/LittleDB/LittleDB.cpp
+++ b/lib/LittleDB/LittleDB.cpp
@@ -653,11 +653,15 @@ int8_t updateRowWithID(
 
   uint8_t findResult = findRowWithID(tblFile, tblName, idValue, EQUAL_OPERATOR);
   if(findResult != RES_OK) {
+    schemFile.close();
+    tblFile.close();
     return findResult;
   }
 
   uint8_t deleteResult = deleteRowWithID(tblFile, idValue);
   if(deleteResult != RES_OK) {
+    schemFile.close();
+    tblFile.close();
     return deleteResult;
   }
   tblFile.close();


### PR DESCRIPTION
## Summary
- ensure `updateRowWithID` closes files on early return

## Testing
- `make test` *(fails: Nothing to be done)*

------
https://chatgpt.com/codex/tasks/task_e_6840980568648324a9312ec080ead4c4